### PR TITLE
fix: only disable signer events_observer, not api events

### DIFF
--- a/conf/mainnet/Config.toml.sample
+++ b/conf/mainnet/Config.toml.sample
@@ -19,9 +19,9 @@ peer_port = 8333
 auth_token = "1234"
 private_neighbors = false
 
-[[events_observer]]
-events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
-endpoint = "stacks-signer:30000"
+#[[events_observer]]
+#events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+#endpoint = "stacks-signer:30000"
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"

--- a/conf/mocknet/Config.toml.sample
+++ b/conf/mocknet/Config.toml.sample
@@ -11,9 +11,9 @@ chain = "bitcoin"
 mode = "mocknet"
 commit_anchor_block_within = 5000
 
-[[events_observer]]
-events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
-endpoint = "stacks-signer:30000"
+#[[events_observer]]
+#events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+#endpoint = "stacks-signer:30000"
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"

--- a/conf/testnet/Config.toml.sample
+++ b/conf/testnet/Config.toml.sample
@@ -20,9 +20,9 @@ pox_reward_length = 900
 auth_token = "1234"
 private_neighbors = false
 
-[[events_observer]]
-events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
-endpoint = "stacks-signer:30000"
+#[[events_observer]]
+#events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+#endpoint = "stacks-signer:30000"
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"


### PR DESCRIPTION
  - [x] Updated Config.toml processing to preserve blockchain-api event configuration
  - [x] Replaced platform-specific sed commands with portable awk implementation